### PR TITLE
商品一覧表示機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
 
   def index
-  #  @items = Item.all
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,9 +128,7 @@
     </div>
     <ul class='item-lists'>
 
-        <% @items.each do |item| %>
-
-      
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
@@ -155,9 +153,9 @@
             </div>
           </div>
         </div>
-         <% end %>
         <% end %>
       </li>
+        <% end %>
 
    <% if @items.length == 0 %>
      <li class='list'>
@@ -175,10 +173,10 @@
             </div>
           </div>
         </div>
-        <% end %>      
       <% end %>
       </li>
     </ul>
+  <% end %>      
   </div>
   <%# /商品一覧 %>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,10 +129,13 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+        <% @items.each do |item| %>
+
+      
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -143,16 +146,17 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
+         <% end %>
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,6 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
         <% @items.each do |item| %>
 
       
@@ -159,11 +158,9 @@
          <% end %>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
+   <% if @items.length == 0 %>
+     <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
@@ -178,16 +175,16 @@
             </div>
           </div>
         </div>
-        <% end %>
+        <% end %>      
+      <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>
 </div>
+
 <%= link_to('/items/new', class: 'purchase-btn') do %>
-  <span class='purchase-btn-text'>出品する</span>
+ <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
 <% end %>
 <%= render partial: "devise/shared/footer"  %>


### PR DESCRIPTION
#  what 
商品一覧機能の実装

#  why 
トップページに一覧の表示をするため

[- 商品のデータがない場合は、ダミー商品が表示されている動画
](https://gyazo.com/af6b5224eb25d688597e91e08562e233)

[商品のデータがある場合は、ダミー商品が表示されない画像](https://gyazo.com/5b984b7d9d0faabe7605a0de4eef8ec8)

[- 商品のデータがある場合は、商品が一覧で表示されている動画](https://gyazo.com/175ad391da8b39ef3d4b42e3cef77991)

[出品画像が存在するときはダミー商品が表示されない様子](https://gyazo.com/ccfca050bce57306d319f34930c3dcdd)